### PR TITLE
Use environment's python install, added MEGA instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ You'll need Python on your desktop, as well as the Python library pyserial (try 
 
 1. Open the example JTAGWhisperer sketch. Upload it to your Arduino.
 
-1. Get a Xilinx XC9572XL CPLD. Hook up your CPLD's JTAG pins to the Arduino: pins 8, 9, 10, 11 to TMS, TDI, TDO, and TCK, respectively. (If you have TCK on pin 11, you probably did it right.)
+1. Get a Xilinx XC9572XL CPLD. Hook up your CPLD's JTAG pins to the Arduino: pins 8, 9, 10, 11 to TMS, TDI, TDO, and TCK, respectively. (If you have TCK on pin 11, you probably did it right.) On an Arduino MEGA or MEGA2560, use pins 53, 52, 51, 50 accordingly.
 
-1. Apply power to the CPLD (note that it's a 3.3-volt device!). Try asking it its device ID as follows, from the root of the source directory:
+1. Apply power to the CPLD (note that it's a 3.3-volt device!). Do not forget so set VIO to 3.3V. Try asking it its device ID as follows, from the root of the source directory:
 
 `./send_xsvf -p /dev/tty.your_arduino_serial_port xsvf/XC9572XL/DeviceID.xsvf`
 

--- a/send_xsvf
+++ b/send_xsvf
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # The JTAG Whisperer https://github.com/sowbug/JTAGWhisperer
 # Copyright 2012 Mike Tsao http://www.sowbug.com/


### PR DESCRIPTION
Will also honor parallel installs via their various python_select / port select mechanisms and their respective module repositories.

MEGA works out of the box if you use its equivalent pin set.
